### PR TITLE
removed empty constructor from OpeningActivty

### DIFF
--- a/app/src/main/java/au/edu/itc539/opencvandroid/OpeningActivity.java
+++ b/app/src/main/java/au/edu/itc539/opencvandroid/OpeningActivity.java
@@ -49,8 +49,6 @@ public class OpeningActivity extends Activity {
 
     int Y_TERM = 920;
 
-    OpeningActivity() {
-    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
 - getting illegal access to constructor error on

the lollipop phone.